### PR TITLE
Set $single to false for checkboxes and select lists in get_post_meta()

### DIFF
--- a/class-atg-meta-box.php
+++ b/class-atg-meta-box.php
@@ -128,7 +128,7 @@ class ATG_Meta_Box {
 
 		foreach ( $this->fields as $field ) {
 			$field_meta_id  = '_' . $this->prefix . '_' . $field['id'];
-			$field['value'] = get_post_meta( $post->ID, $field_meta_id, true );
+			$field['value'] = in_array( $field['type'], array( 'checkboxes', 'select') ) ? get_post_meta( $post->ID, $field_meta_id, false ) : get_post_meta( $post->ID, $field_meta_id, true );
 			echo $this->_get_field_html( $field );
 		}
 	}


### PR DESCRIPTION
I noticed checkboxes and select lists were only being populated with a single stored value.  Setting that 3rd arg in get_post_meta to false for those types seems to work for me.
